### PR TITLE
#27060 -- Add db_index support

### DIFF
--- a/django/contrib/gis/management/commands/inspectdb.py
+++ b/django/contrib/gis/management/commands/inspectdb.py
@@ -14,3 +14,13 @@ class Command(InspectDBCommand):
             field_type, geo_params = connection.introspection.get_geometry_type(table_name, row)
             field_params.update(geo_params)
         return field_type, field_params, field_notes
+
+    def _get_field_constrains_params(self, connection, constraints, table_name, column_name,
+                                     is_relation, is_primary_key, row):
+        extra_params, field_notes = super()._get_field_constrains_params(
+            connection, constraints, table_name, column_name,
+            is_relation, is_primary_key, row)
+        field_type, _, _ = super().get_field_type(connection, table_name, row)
+        if field_type == 'GeometryField' and extra_params.get('db_index'):
+            del extra_params['db_index']
+        return extra_params, field_notes

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -83,6 +83,10 @@ class Command(BaseCommand):
                         c['columns'][0] for c in constraints.values()
                         if c['unique'] and len(c['columns']) == 1
                     ]
+                    db_index_columns = [
+                        c['columns'][0] for c in constraints.values()
+                        if c['index']  and len(c['columns']) == 1
+                    ]                    
                     table_description = connection.introspection.get_table_description(cursor, table_name)
                 except Exception as e:
                     yield "# Unable to inspect table '%s'" % table_name
@@ -109,11 +113,14 @@ class Command(BaseCommand):
                     used_column_names.append(att_name)
                     column_to_field_name[column_name] = att_name
 
-                    # Add primary_key and unique, if necessary.
+                    # Add primary_key, unique and db_index, if necessary.
                     if column_name == primary_key_column:
                         extra_params['primary_key'] = True
-                    elif column_name in unique_columns:
-                        extra_params['unique'] = True
+                    else:
+                        if column_name in unique_columns:
+                            extra_params['unique'] = True
+                        if column_name in db_index_columns:
+                            extra_params['db_index'] = True
 
                     if is_relation:
                         if extra_params.pop('unique', False) or extra_params.get('primary_key'):

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -119,7 +119,7 @@ class Command(BaseCommand):
                     else:
                         if column_name in unique_columns:
                             extra_params['unique'] = True
-                        if column_name in db_index_columns:
+                        if column_name in db_index_columns and not is_relation:
                             extra_params['db_index'] = True
 
                     if is_relation:

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -85,8 +85,8 @@ class Command(BaseCommand):
                     ]
                     db_index_columns = [
                         c['columns'][0] for c in constraints.values()
-                        if c['index']  and len(c['columns']) == 1
-                    ]                    
+                        if c['index'] and len(c['columns']) == 1
+                    ]
                     table_description = connection.introspection.get_table_description(cursor, table_name)
                 except Exception as e:
                     yield "# Unable to inspect table '%s'" % table_name

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -69,7 +69,7 @@ class InspectDBTestCase(TestCase):
             assertFieldType('email_field', "models.CharField(max_length=254)")
             assertFieldType('file_field', "models.CharField(max_length=100)")
             assertFieldType('file_path_field', "models.CharField(max_length=100)")
-            assertFieldType('slug_field', "models.CharField(max_length=50)")
+            assertFieldType('slug_field', "models.CharField(db_index=True, max_length=50)")
             assertFieldType('text_field', "models.TextField()")
             assertFieldType('url_field', "models.CharField(max_length=200)")
         assertFieldType('date_field', "models.DateField()")


### PR DESCRIPTION
I'm using `inspectdb` for some legacy Django based projects.

I have a problem with indexes as described here: https://code.djangoproject.com/ticket/27060

I understand that it's not so simple to fix all edge cases. And it is a reason why there has been no activity on this issue for three years.

It will help me if at least `db_index` indexes are supported by the inspectdb.
